### PR TITLE
fix moko-resources missed actual declaration

### DIFF
--- a/kamel-samples/build.gradle.kts
+++ b/kamel-samples/build.gradle.kts
@@ -12,8 +12,8 @@ import org.jetbrains.kotlin.konan.file.File as KonanFile
 plugins {
     multiplatform
     compose
-    mokoResources
     `android-application`
+    mokoResources
 }
 
 android {


### PR DESCRIPTION
as i see we should enable `moko-resources` gradle plugin after AGP plugin to AGP correctly read generated source set